### PR TITLE
split qasm2 core lowering into qasm2.indexing dialect

### DIFF
--- a/src/bloqade/qasm2/dialects/core/__init__.py
+++ b/src/bloqade/qasm2/dialects/core/__init__.py
@@ -1,3 +1,3 @@
-from . import emit as emit, address as address, lowering as lowering
+from . import emit as emit, address as address
 from .stmts import *  # noqa: F403
 from ._dialect import dialect as dialect

--- a/src/bloqade/qasm2/dialects/indexing.py
+++ b/src/bloqade/qasm2/dialects/indexing.py
@@ -1,12 +1,19 @@
+"""This dialect provides the indexing syntax in Python lowering
+for QASM2 dialects. The dialect itself does not contain new statements.
+
+Using this dialect will be conflict with Python semantics provided by
+`kirin.dialects.py.binop` and `kirin.dialects.py.indexing` dialects.
+"""
+
 import ast
 
-from kirin import types
+from kirin import ir, types
 from kirin.lowering import Result, FromPythonAST, LoweringState
 from kirin.exceptions import DialectLoweringError
 from bloqade.qasm2.types import BitType, CRegType, QRegType, QubitType
+from bloqade.qasm2.dialects import core
 
-from . import stmts
-from ._dialect import dialect
+dialect = ir.Dialect("qasm2.indexing")
 
 
 @dialect.register
@@ -19,7 +26,7 @@ class QASMCoreLowering(FromPythonAST):
             )
         rhs = state.visit(node.comparators[0]).expect_one()
         if isinstance(node.ops[0], ast.Eq):
-            stmt = stmts.CRegEq(lhs, rhs)
+            stmt = core.CRegEq(lhs, rhs)
         else:
             raise DialectLoweringError(
                 f"unsupported comparison operator {node.ops[0]} only Eq is supported."
@@ -44,10 +51,10 @@ class QASMCoreLowering(FromPythonAST):
             )
 
         if value.type.is_subseteq(QRegType):
-            stmt = stmts.QRegGet(reg=value, idx=index)
+            stmt = core.QRegGet(reg=value, idx=index)
             stmt.result.type = QubitType
         elif value.type.is_subseteq(CRegType):
-            stmt = stmts.CRegGet(reg=value, idx=index)
+            stmt = core.CRegGet(reg=value, idx=index)
             stmt.result.type = BitType
         else:
             raise DialectLoweringError(

--- a/src/bloqade/qasm2/groups.py
+++ b/src/bloqade/qasm2/groups.py
@@ -1,6 +1,6 @@
 from kirin import ir, passes
 from kirin.dialects import cf, func, ilist
-from bloqade.qasm2.dialects import uop, core, expr, inline, parallel
+from bloqade.qasm2.dialects import uop, core, expr, inline, indexing, parallel
 
 
 @ir.dialect_group([uop, parallel, func, ilist, expr])
@@ -27,7 +27,7 @@ def gate(self):
     return run_pass
 
 
-@ir.dialect_group([inline, uop, expr, parallel, core, cf, ilist, func])
+@ir.dialect_group([inline, uop, expr, parallel, core, indexing, cf, ilist, func])
 def main(self):
     ilist_desugar = ilist.IListDesugar(self)
     fold_pass = passes.Fold(self)


### PR DESCRIPTION
this splits the lowering so one can opt-out the QASM2 syntax sugar defined for a Python frontend if one is fine with not being strictly compatible with QASM2, e.g you can write the following by mixing QASM2 `uop`, `core` dialects with `basic` (from @jon-wurtz 's issue https://github.com/QuEraComputing/kirin/issues/170)

```python
def qaoa(n_qubits, graph):
    n_nodes = len(graph.nodes)
    edges = ilist.IList(list(G.edges))

    @basic_no_opt.union([qasm2.uop, qasm2.core])
    def qaoa_kernerl(gamma: ilist.IList[float, Any], beta: ilist.IList[float, Any]):
        qreg = qasm2.qreg(n_qubits)
        def apply_h(i: int):
            qasm2.H(qreg[i])
        ilist.ForEach(apply_h, range(n_nodes))

        def apply(idx: int):
            def apply_edge(e: tuple[int, int]):
                qasm2.CRX(qreg[e[0]], qreg[e[1]], gamma[idx])
            ilist.ForEach(apply_edge, edges)
            def apply_node(i: int):
                qasm2.RX(qreg[i], beta[idx])
            ilist.ForEach(apply_node, range(n_nodes))

        ilist.ForEach(apply, range(len(gamma)))

    return qaoa_kernerl
```