### PR TITLE
Documentation for global to UOp Pass

### DIFF
--- a/src/bloqade/qasm2/passes/glob.py
+++ b/src/bloqade/qasm2/passes/glob.py
@@ -1,3 +1,8 @@
+"""
+Passes that deal with global gates. As of now, only one rewrite pass exists
+which converts global gates to single qubit gates.
+"""
+
 from kirin import ir
 from kirin.rewrite import cse, dce, walk, result
 from bloqade.analysis import address
@@ -6,6 +11,41 @@ from bloqade.qasm2.rewrite import GlobalToUOpRule
 
 
 class GlobalToUOP(Pass):
+    """Pass to convert Global gates into single gates.
+
+    This pass rewrites the global unitary gate from the `qasm2.glob` dialect into multiple
+    single gates in the `qasm2.uop` dialect, bringing the program closer to
+    conforming to standard QASM2 syntax.
+
+
+    ## Usage Examples
+    ```
+    # Define kernel
+    @qasm2.extended
+    def main():
+        q1 = qasm2.qreg(1)
+        q2 = qasm2.qreg(2)
+
+        theta = 1.3
+        phi = 1.1
+        lam = 1.2
+
+        qasm2.glob.u(theta=theta, phi=phi, lam=lam, registers=[q1, q2])
+
+    GlobalToUOP(dialects=main.dialects)(main)
+
+    # Run rewrite
+    GlobalToUOP(main.dialects)(main)
+    ```
+
+    The `qasm2.glob.u` statement has been rewritten to individual gates:
+
+    ```
+    qasm2.uop.u(q1[0], theta, phi, lam)
+    qasm2.uop.u(q1[0], theta, phi, lam)
+    qasm2.uop.u(q2[1], theta, phi, lam)
+    ```
+    """
 
     def generate_rule(self, mt: ir.Method) -> GlobalToUOpRule:
         results, _ = address.AddressAnalysis(mt.dialects).run_analysis(mt)


### PR DESCRIPTION
Figured if I already knocked out the parallel passes in #96 I could do the same for `glob.py` (: 