### PR TITLE
fix folding in GHZ example

### DIFF
--- a/docs/digital/examples/ghz.py
+++ b/docs/digital/examples/ghz.py
@@ -143,3 +143,9 @@ def ghz_log_simd(n: int):
 # As a result, the returned QASM2 program will not have any arguments.
 # </p>
 # </div>
+
+target = qasm2.emit.QASM2(
+    allow_parallel=True,
+)
+ast = target.emit(ghz_log_simd(4))
+qasm2.parse.pprint(ast)


### PR DESCRIPTION
This fix #144 
TL;DR 

there are a few bugs here

1. type inference is not returning the correct type for `range` due to https://github.com/QuEraComputing/kirin/pull/296 so this will be pending on a minor version of Kirin
2. the `ilist.rewrite.Unroll` expects type inference to figure out the shape of the IList object, but we need to do a round of rewrite to correct the type of `py.constant` statement containing an `IList` (otherwise it will be just a `PyClass(IList)` which is not wrong but not precise enough to trigger the unroll) TODO: maybe we should just let unroll also lookup constants on Kirin side? this would be more robust to have both I think.
3. we should run a round of type inference after we unroll and inline the `invoke`s because some of the type has been too loose and now more precise information is available.