### PR TITLE
Fixing bug in `UOpToParallelRule`

### DIFF
--- a/src/bloqade/analysis/schedule.py
+++ b/src/bloqade/analysis/schedule.py
@@ -60,10 +60,12 @@ class StmtDag(graph.Graph[ir.Statement]):
     stmts: Dict[str, ir.Statement] = field(default_factory=OrderedDict)
     out_edges: Dict[str, Set[str]] = field(default_factory=OrderedDict)
     inc_edges: Dict[str, Set[str]] = field(default_factory=OrderedDict)
+    stmt_index: Dict[ir.Statement, int] = field(default_factory=OrderedDict)
 
     def add_node(self, node: ir.Statement):
         node_id = self.id_table[node]
         self.stmts[node_id] = node
+        self.stmt_index[node] = len(self.stmt_index)
         self.out_edges.setdefault(node_id, set())
         self.inc_edges.setdefault(node_id, set())
         return node_id

--- a/src/bloqade/analysis/schedule.py
+++ b/src/bloqade/analysis/schedule.py
@@ -214,7 +214,7 @@ class DagScheduleAnalysis(Forward[GateSchedule]):
                 self._update_dag(stmt, sub_addr)
 
     def update_dag(self, stmt: ir.Statement, args: Sequence[ir.SSAValue]):
-        self.stmt_dag.update_index(stmt)
+        self.stmt_dag.add_node(stmt)
 
         for arg in args:
             self._update_dag(

--- a/src/bloqade/analysis/schedule.py
+++ b/src/bloqade/analysis/schedule.py
@@ -214,8 +214,7 @@ class DagScheduleAnalysis(Forward[GateSchedule]):
                 self._update_dag(stmt, sub_addr)
 
     def update_dag(self, stmt: ir.Statement, args: Sequence[ir.SSAValue]):
-        if stmt not in self.stmt_dag.stmt_index:
-            self.stmt_dag.add_node(stmt)
+        self.stmt_dag.update_index(stmt)
 
         for arg in args:
             self._update_dag(

--- a/src/bloqade/qasm2/passes/parallel.py
+++ b/src/bloqade/qasm2/passes/parallel.py
@@ -22,7 +22,7 @@ from bloqade.qasm2.rewrite import (
     MergePolicyABC,
     ParallelToUOpRule,
     UOpToParallelRule,
-    SimpleGreedyMergePolicy,
+    SimpleOptimalMergePolicy,
 )
 
 
@@ -129,7 +129,7 @@ class UOpToParallel(Pass):
 
     """
 
-    merge_policy_type: Type[MergePolicyABC] = SimpleGreedyMergePolicy
+    merge_policy_type: Type[MergePolicyABC] = SimpleOptimalMergePolicy
 
     def generate_rule(self, mt: ir.Method):
         frame, _ = address.AddressAnalysis(mt.dialects).run_analysis(mt)
@@ -145,11 +145,4 @@ class UOpToParallel(Pass):
         )
 
     def unsafe_run(self, mt: ir.Method) -> result.RewriteResult:
-        result = Walk(self.generate_rule(mt)).rewrite(mt.code)
-
-        rule = Chain(
-            ConstantFold(),
-            DeadCodeElimination(),
-            CommonSubexpressionElimination(),
-        )
-        return Fixpoint(Walk(rule)).rewrite(mt.code).join(result)
+        return Walk(self.generate_rule(mt)).rewrite(mt.code)

--- a/src/bloqade/qasm2/rewrite/native_gates.py
+++ b/src/bloqade/qasm2/rewrite/native_gates.py
@@ -4,6 +4,7 @@ from functools import cached_property
 from dataclasses import field, dataclass
 
 import cirq
+import numpy as np
 import cirq.transformers
 import cirq.contrib.qasm_import
 import cirq.transformers.target_gatesets
@@ -68,12 +69,15 @@ class CU(cirq.Gate):
         return "*", "CU"
 
 
+def around(val):
+    return float(np.around(val, 14))
+
+
 def one_qubit_gate_to_u3_angles(op: cirq.Operation) -> tuple[float, float, float]:
     lam, theta, phi = (  # Z angle, Y angle, then Z angle
         cirq.deconstruct_single_qubit_matrix_into_angles(cirq.unitary(op))
     )
-
-    return theta, phi, lam
+    return tuple(map(around, (theta, phi, lam)))
 
 
 @dataclass

--- a/src/bloqade/qasm2/rewrite/uop_to_parallel.py
+++ b/src/bloqade/qasm2/rewrite/uop_to_parallel.py
@@ -133,7 +133,7 @@ class SimpleMergePolicy(MergePolicyABC):
 
         for group in merge_groups:
             group.sort(key=lambda stmt: dag.stmt_index[stmt])
-            
+
         return cls(
             address_analysis=address_analysis,
             merge_groups=merge_groups,

--- a/test/qasm2/passes/test_uop_to_parallel.py
+++ b/test/qasm2/passes/test_uop_to_parallel.py
@@ -1,5 +1,6 @@
 from bloqade import qasm2
 from bloqade.qasm2 import glob
+from bloqade.analysis import address
 from bloqade.qasm2.passes import parallel
 from bloqade.qasm2.rewrite import SimpleOptimalMergePolicy
 
@@ -34,24 +35,43 @@ def test_one():
     parallel.UOpToParallel(test.dialects)(test)
     test.print()
 
+    # add this to raise error if there are broken ssa references
+    _, _ = address.AddressAnalysis(test.dialects).run_analysis(test, no_raise=False)
+
 
 def test_two():
 
     @qasm2.extended
     def test():
         q = qasm2.qreg(8)
+        theta = 0.1
+        theta2 = 0.4
+        phi = 0.2
+        lam = 0.3
 
         qasm2.rz(q[0], 0.8)
         qasm2.rz(q[1], 0.7)
+
+        qasm2.u(q[1], theta, phi, lam)
+        qasm2.u(q[0], theta2, phi, lam)
+
         qasm2.rz(q[2], 0.6)
         qasm2.rz(q[3], 0.5)
+
+        qasm2.u(q[3], theta, phi, lam)
+        qasm2.u(q[2], theta2, phi, lam)
+
         qasm2.rz(q[4], 0.5)
         qasm2.rz(q[5], 0.6)
+
+        qasm2.u(q[4], theta, phi, lam)
+        qasm2.u(q[5], 0.4, phi, lam)
+
         qasm2.rz(q[6], 0.7)
         qasm2.rz(q[7], 0.8)
 
     parallel.UOpToParallel(test.dialects, SimpleOptimalMergePolicy)(test)
     test.print()
 
-
-test_one()
+    # add this to raise error if there are broken ssa references
+    _, _ = address.AddressAnalysis(test.dialects).run_analysis(test, no_raise=False)

--- a/test/qasm2/passes/test_uop_to_parallel.py
+++ b/test/qasm2/passes/test_uop_to_parallel.py
@@ -52,3 +52,5 @@ def test_two():
 
     parallel.UOpToParallel(test.dialects, SimpleOptimalMergePolicy)(test)
     test.print()
+
+test_one()

--- a/test/qasm2/passes/test_uop_to_parallel.py
+++ b/test/qasm2/passes/test_uop_to_parallel.py
@@ -53,4 +53,5 @@ def test_two():
     parallel.UOpToParallel(test.dialects, SimpleOptimalMergePolicy)(test)
     test.print()
 
+
 test_one()


### PR DESCRIPTION
The rewrite works by picking an arbitrary gate instruction in the gate instructions that have been marked to be merged and then moving the qubits to be close to that node. That is problematic in situations where a register is defined after that node. I attempted to fix this by moving all dependencies, but this didn't seem to work and is very complicated to check in different situations, e.g., when the SSA values are block arguments. So, instead, I decided that the solution is to just sort the gate instructions in order of when they appear in the IR, making their global ordering in the DAG. In that way, I can do the parallel rewrite on the gate that appears last in the order of gates, ensuring that all ssa dependencies are indeed available for the rewrite. 

EDIT: The bug manifests as broken SSA references so I am running the address analysis causes the tests to raise exceptions for catching this particular error. 