### PR TITLE
Set font to Lato

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,8 @@ theme:
   name: material
   favicon: assets/favicon.ico
   logo: assets/logo-dark.svg
+  font:
+    text: Lato
   palette:
     - scheme: default
       primary: custom


### PR DESCRIPTION
This should fix part of the issue @cduck brought up here https://github.com/QuEraComputing/bloqade-analog/issues/1014 with the fonts being slightly different. In bloqade-analog I remember setting the font to Lato because that was what the Bloqade.jl docs used. Now I've propagated that change to the new docs here. 