### PR TITLE
Fix bug in UOpToParallel

### DIFF
--- a/src/bloqade/qasm2/rewrite/__init__.py
+++ b/src/bloqade/qasm2/rewrite/__init__.py
@@ -2,6 +2,7 @@ from .glob import (
     GlobalToUOpRule as GlobalToUOpRule,
     GlobalToParallelRule as GlobalToParallelRule,
 )
+from .register import RaiseRegisterRule as RaiseRegisterRule
 from .parallel_to_uop import ParallelToUOpRule as ParallelToUOpRule
 from .uop_to_parallel import (
     MergePolicyABC as MergePolicyABC,

--- a/src/bloqade/qasm2/rewrite/register.py
+++ b/src/bloqade/qasm2/rewrite/register.py
@@ -1,0 +1,44 @@
+from kirin import ir
+from kirin.dialects import py
+from kirin.rewrite.abc import RewriteRule, RewriteResult
+from bloqade.qasm2.dialects import core
+
+
+class RaiseRegisterRule(RewriteRule):
+    """This rule puts all registers at the top of the block.
+
+    This is required for the UOpToParallel rules to work correctly
+    to handle cases where a register is defined in between two statements
+    that can be parallelized.
+
+    """
+
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        if not isinstance(node, core.QRegNew):
+            return RewriteResult()
+
+        if node.parent_block is None or node.parent_block.first_stmt is None:
+            return RewriteResult()
+
+        first_stmt = node.parent_block.first_stmt
+
+        n_qubits_ref = node.n_qubits
+
+        n_qubits = n_qubits_ref.owner
+        if isinstance(n_qubits, py.Constant):
+            # case where the n_qubits comes from a constant
+            new_n_qubits = n_qubits.from_stmt(n_qubits)
+            new_n_qubits.insert_before(first_stmt)
+            new_n_qubits_ref = new_n_qubits.result
+
+        elif isinstance(n_qubits, ir.BlockArgument):
+            # case where the n_qubits comes from a block argument
+            new_n_qubits_ref = n_qubits
+        else:
+            return RewriteResult()
+
+        new_qreg_stmt = core.QRegNew(n_qubits=new_n_qubits_ref)
+        new_qreg_stmt.insert_before(first_stmt)
+        node.result.replace_by(new_qreg_stmt.result)
+        node.delete()
+        return RewriteResult(has_done_something=True)

--- a/test/qasm2/passes/test_uop_to_parallel.py
+++ b/test/qasm2/passes/test_uop_to_parallel.py
@@ -75,3 +75,25 @@ def test_two():
 
     # add this to raise error if there are broken ssa references
     _, _ = address.AddressAnalysis(test.dialects).run_analysis(test, no_raise=False)
+
+
+def test_three():
+
+    @qasm2.extended
+    def test():
+        q1 = qasm2.qreg(1)
+        qasm2.u(q1[0], 0.1, 0.2, 0.3)
+
+        q2 = qasm2.qreg(1)
+        qasm2.u(q2[0], 0.1, 0.2, 0.3)
+        qasm2.cz(q2[0], q1[0])
+
+        q3 = qasm2.qreg(1)
+        qasm2.u(q3[0], 0.1, 0.2, 0.3)
+        qasm2.cz(q3[0], q2[0])
+
+    parallel.UOpToParallel(test.dialects)(test)
+    test.print()
+
+    # add this to raise error if there are broken ssa references
+    _, _ = address.AddressAnalysis(test.dialects).run_analysis(test, no_raise=False)


### PR DESCRIPTION
The previous patch was incorrect the gates can't move to the last gate in the group becase that could potentially move a gate through another gate it doesn't commute with, the opposite isn't true because the operations occur in order of when they occur first in the IR. One issue is that if you move the gates earlier, you need to move the references to the qubits and also the registers as well. As such, I have added an extra rewrite that moves all register definitions to the top of their block. This should be fine in most cases since I optimize per block anyway. 