### PR TITLE
RFC: structural quantum instruction language

### DIFF
--- a/src/bloqade/squin/__init__.py
+++ b/src/bloqade/squin/__init__.py
@@ -1,0 +1,2 @@
+from . import op as op, wire as wire, qubit as qubit
+from .groups import wired as wired, kernel as kernel

--- a/src/bloqade/squin/groups.py
+++ b/src/bloqade/squin/groups.py
@@ -1,0 +1,20 @@
+from kirin import ir
+from kirin.prelude import structural_no_opt
+
+from . import op, wire, qubit
+
+
+@ir.dialect_group(structural_no_opt.union([op, qubit]))
+def kernel(self):
+    def run_pass(method):
+        pass
+
+    return run_pass
+
+
+@ir.dialect_group(structural_no_opt.union([op, wire]))
+def wired(self):
+    def run_pass(method):
+        pass
+
+    return run_pass

--- a/src/bloqade/squin/op/__init__.py
+++ b/src/bloqade/squin/op/__init__.py
@@ -1,0 +1,132 @@
+from kirin import ir as _ir
+from kirin.prelude import structural_no_opt as _structural_no_opt
+from kirin.lowering import wraps as _wraps
+
+from . import stmts as stmts, types as types
+from .traits import Unitary as Unitary, MaybeUnitary as MaybeUnitary
+from ._dialect import dialect as dialect
+
+
+@_wraps(stmts.Kron)
+def kron(lhs: types.Op, rhs: types.Op, *, is_unitary: bool = False) -> types.Op: ...
+
+
+@_wraps(stmts.Adjoint)
+def adjoint(op: types.Op, *, is_unitary: bool = False) -> types.Op: ...
+
+
+@_wraps(stmts.Control)
+def control(op: types.Op, *, n_controls: int, is_unitary: bool = False) -> types.Op: ...
+
+
+@_wraps(stmts.Identity)
+def identity(*, size: int) -> types.Op: ...
+
+
+@_wraps(stmts.Rot)
+def rot(axis: types.Op, angle: float) -> types.Op: ...
+
+
+@_wraps(stmts.ShiftOp)
+def shift(theta: float) -> types.Op: ...
+
+
+@_wraps(stmts.PhaseOp)
+def phase(theta: float) -> types.Op: ...
+
+
+@_wraps(stmts.X)
+def x() -> types.Op: ...
+
+
+@_wraps(stmts.Y)
+def y() -> types.Op: ...
+
+
+@_wraps(stmts.Z)
+def z() -> types.Op: ...
+
+
+@_wraps(stmts.H)
+def h() -> types.Op: ...
+
+
+@_wraps(stmts.S)
+def s() -> types.Op: ...
+
+
+@_wraps(stmts.T)
+def t() -> types.Op: ...
+
+
+@_wraps(stmts.P0)
+def p0() -> types.Op: ...
+
+
+@_wraps(stmts.P1)
+def p1() -> types.Op: ...
+
+
+@_wraps(stmts.Sn)
+def spin_n() -> types.Op: ...
+
+
+@_wraps(stmts.Sp)
+def spin_p() -> types.Op: ...
+
+
+# stdlibs
+@_ir.dialect_group(_structural_no_opt.add(dialect))
+def op(self):
+    def run_pass(method):
+        pass
+
+    return run_pass
+
+
+@op
+def rx(theta: float) -> types.Op:
+    """Rotation X gate."""
+    return rot(x(), theta)
+
+
+@op
+def ry(theta: float) -> types.Op:
+    """Rotation Y gate."""
+    return rot(y(), theta)
+
+
+@op
+def rz(theta: float) -> types.Op:
+    """Rotation Z gate."""
+    return rot(z(), theta)
+
+
+@op
+def cx() -> types.Op:
+    """Controlled X gate."""
+    return control(x(), n_controls=1)
+
+
+@op
+def cy() -> types.Op:
+    """Controlled Y gate."""
+    return control(y(), n_controls=1)
+
+
+@op
+def cz() -> types.Op:
+    """Control Z gate."""
+    return control(z(), n_controls=1)
+
+
+@op
+def ch() -> types.Op:
+    """Control H gate."""
+    return control(h(), n_controls=1)
+
+
+@op
+def cphase(theta: float) -> types.Op:
+    """Control Phase gate."""
+    return control(phase(theta), n_controls=1)

--- a/src/bloqade/squin/op/_dialect.py
+++ b/src/bloqade/squin/op/_dialect.py
@@ -1,0 +1,3 @@
+from kirin import ir
+
+dialect = ir.Dialect("squin.op")

--- a/src/bloqade/squin/op/stmts.py
+++ b/src/bloqade/squin/op/stmts.py
@@ -1,0 +1,200 @@
+from kirin import ir, types
+from kirin.decl import info, statement
+
+from .types import OpType
+from .traits import Unitary, MaybeUnitary
+from ._dialect import dialect
+
+
+@statement
+class Operator(ir.Statement):
+    pass
+
+
+@statement
+class PrimitiveOp(Operator):
+    pass
+
+
+@statement
+class CompositeOp(Operator):
+    pass
+
+
+@statement
+class BinaryOp(CompositeOp):
+    lhs: ir.SSAValue = info.argument(OpType)
+    rhs: ir.SSAValue = info.argument(OpType)
+    result: ir.ResultValue = info.result(OpType)
+
+
+@statement(dialect=dialect)
+class Kron(BinaryOp):
+    traits = frozenset({ir.Pure(), ir.FromPythonCall(), MaybeUnitary()})
+    is_unitary: bool = info.attribute()
+
+
+@statement(dialect=dialect)
+class Mult(BinaryOp):
+    traits = frozenset({ir.Pure(), ir.FromPythonCall(), MaybeUnitary()})
+    is_unitary: bool = info.attribute()
+
+
+@statement(dialect=dialect)
+class Adjoint(CompositeOp):
+    traits = frozenset({ir.Pure(), ir.FromPythonCall(), MaybeUnitary()})
+    is_unitary: bool = info.attribute()
+    op: ir.SSAValue = info.argument(OpType)
+    result: ir.ResultValue = info.result(OpType)
+
+
+@statement(dialect=dialect)
+class Control(CompositeOp):
+    traits = frozenset({ir.Pure(), ir.FromPythonCall(), MaybeUnitary()})
+    is_unitary: bool = info.attribute()
+    op: ir.SSAValue = info.argument(OpType)
+    n_controls: int = info.attribute()
+    result: ir.ResultValue = info.result(OpType)
+
+
+@statement(dialect=dialect)
+class Rot(CompositeOp):
+    traits = frozenset({ir.Pure(), ir.FromPythonCall(), Unitary()})
+    axis: ir.SSAValue = info.argument(OpType)
+    angle: ir.SSAValue = info.attribute(types.Float)
+    result: ir.ResultValue = info.result(OpType)
+
+
+@statement(dialect=dialect)
+class Identity(CompositeOp):
+    traits = frozenset({ir.Pure(), ir.FromPythonCall(), Unitary()})
+    size: int = info.attribute()
+    result: ir.ResultValue = info.result(OpType)
+
+
+@statement
+class ConstantOp(PrimitiveOp):
+    traits = frozenset({ir.Pure(), ir.FromPythonCall(), ir.ConstantLike()})
+    result: ir.ResultValue = info.result(OpType)
+
+
+@statement
+class ConstantUnitary(ConstantOp):
+    traits = frozenset({ir.Pure(), ir.FromPythonCall(), ir.ConstantLike(), Unitary()})
+
+
+@statement(dialect=dialect)
+class PhaseOp(PrimitiveOp):
+    """
+    A phase operator.
+
+    $$
+    PhaseOp(theta) = e^{i \theta} I
+    $$
+    """
+
+    traits = frozenset({ir.Pure(), ir.FromPythonCall(), Unitary()})
+    theta: ir.SSAValue = info.argument(types.Float)
+    result: ir.ResultValue = info.result(OpType)
+
+
+@statement(dialect=dialect)
+class Shift(PrimitiveOp):
+    """
+    A phase shift operator.
+
+    $$
+    Shift(theta) = \\begin{bmatrix} 1 & 0 \\\\ 0 & e^{i \\theta} \\end{bmatrix}
+    $$
+    """
+
+    traits = frozenset({ir.Pure(), ir.FromPythonCall(), Unitary()})
+    theta: ir.SSAValue = info.argument(types.Float)
+    result: ir.ResultValue = info.result(OpType)
+
+
+@statement
+class PauliOp(ConstantUnitary):
+    pass
+
+
+@statement(dialect=dialect)
+class X(PauliOp):
+    pass
+
+
+@statement(dialect=dialect)
+class Y(PauliOp):
+    pass
+
+
+@statement(dialect=dialect)
+class Z(PauliOp):
+    pass
+
+
+@statement(dialect=dialect)
+class H(ConstantUnitary):
+    pass
+
+
+@statement(dialect=dialect)
+class S(ConstantUnitary):
+    pass
+
+
+@statement(dialect=dialect)
+class T(ConstantUnitary):
+    pass
+
+
+@statement(dialect=dialect)
+class P0(ConstantOp):
+    """
+    The $P_0$ projection operator.
+
+    $$
+    P0 = \\begin{bmatrix} 1 & 0 \\\\ 0 & 0 \\end{bmatrix}
+    $$
+    """
+
+    pass
+
+
+@statement(dialect=dialect)
+class P1(ConstantOp):
+    """
+    The $P_1$ projection operator.
+
+    $$
+    P1 = \\begin{bmatrix} 0 & 0 \\\\ 0 & 1 \\end{bmatrix}
+    $$
+    """
+
+    pass
+
+
+@statement(dialect=dialect)
+class Sn(ConstantOp):
+    """
+    $S_{-}$ operator.
+
+    $$
+    Sn = \\frac{1}{2} (S_x - i S_y) = \\frac{1}{2} \\begin{bmatrix} 0 & 0 \\\\ 1 & 0 \\end{bmatrix}
+    $$
+    """
+
+    pass
+
+
+@statement(dialect=dialect)
+class Sp(ConstantOp):
+    """
+    $S_{+}$ operator.
+
+    $$
+    Sp = \\frac{1}{2} (S_x + i S_y) = \\frac{1}{2}\\begin{bmatrix} 0 & 1 \\\\ 0 & 0 \\end{bmatrix}
+    $$
+    """
+
+    pass

--- a/src/bloqade/squin/op/traits.py
+++ b/src/bloqade/squin/op/traits.py
@@ -1,0 +1,23 @@
+from typing import cast
+from dataclasses import dataclass
+
+from kirin import ir
+
+
+@dataclass(frozen=True)
+class Unitary(ir.StmtTrait):
+    pass
+
+
+@dataclass(frozen=True)
+class MaybeUnitary(ir.StmtTrait):
+
+    def is_unitary(self, stmt: ir.Statement):
+        attr = stmt.get_attr_or_prop("is_unitary")
+        if attr is None:
+            return False
+        return cast(ir.PyAttr[bool], attr).data
+
+    def set_unitary(self, stmt: ir.Statement, value: bool):
+        stmt.attributes["is_unitary"] = ir.PyAttr(value)
+        return

--- a/src/bloqade/squin/op/traits.py
+++ b/src/bloqade/squin/op/traits.py
@@ -5,6 +5,26 @@ from kirin import ir
 
 
 @dataclass(frozen=True)
+class Sized(ir.StmtTrait):
+    data: int
+
+
+@dataclass(frozen=True)
+class HasSize(ir.StmtTrait):
+    """An operator with a `size` attribute."""
+
+    def get_size(self, stmt: ir.Statement):
+        attr = stmt.get_attr_or_prop("size")
+        if attr is None:
+            raise ValueError(f"Missing size attribute in {stmt}")
+        return cast(ir.PyAttr[int], attr).data
+
+    def set_size(self, stmt: ir.Statement, value: int):
+        stmt.attributes["size"] = ir.PyAttr(value)
+        return
+
+
+@dataclass(frozen=True)
 class Unitary(ir.StmtTrait):
     pass
 

--- a/src/bloqade/squin/op/types.py
+++ b/src/bloqade/squin/op/types.py
@@ -1,0 +1,8 @@
+from kirin import types
+
+
+class Op:
+    pass
+
+
+OpType = types.PyClass(Op)

--- a/src/bloqade/squin/op/types.py
+++ b/src/bloqade/squin/op/types.py
@@ -2,7 +2,9 @@ from kirin import types
 
 
 class Op:
-    pass
+
+    def __matmul__(self, other: "Op") -> "Op":
+        raise NotImplementedError("@ can only be used within a squin kernel program")
 
 
 OpType = types.PyClass(Op)

--- a/src/bloqade/squin/qubit.py
+++ b/src/bloqade/squin/qubit.py
@@ -25,17 +25,10 @@ class New(ir.Statement):
     n_qubits: ir.SSAValue = info.argument(types.Int)
     result: ir.ResultValue = info.result(ilist.IListType[QubitType, types.Any])
 
-    def __init__(self, n_qubits: int):
-        super().__init__(
-            attributes={"n_qubits": ir.PyAttr(n_qubits)},
-            # NOTE: we don't have dependent types in Python, this might be removed
-            #     in the future, if we end up supporting dependent types in Kirin.
-            result_types=(ilist.IListType[QubitType, types.Literal(n_qubits)],),
-        )
-
 
 @statement(dialect=dialect)
 class Apply(ir.Statement):
+    traits = frozenset({ir.FromPythonCall()})
     operator: ir.SSAValue = info.argument(OpType)
     qubits: ir.SSAValue = info.argument(ilist.IListType[QubitType])
 
@@ -74,7 +67,7 @@ def new(n_qubits: int) -> ilist.IList[Qubit, Any]:
 
 
 @wraps(Apply)
-def apply(operator: Op, qubits: ilist.IList[Qubit, Any]) -> None:
+def apply(operator: Op, qubits: ilist.IList[Qubit, Any] | list[Qubit]) -> None:
     """Apply an operator to a list of qubits.
 
     Args:

--- a/src/bloqade/squin/qubit.py
+++ b/src/bloqade/squin/qubit.py
@@ -1,0 +1,124 @@
+"""qubit dialect for squin language.
+
+This dialect defines the operations that can be performed on qubits.
+
+Depends on:
+- `bloqade.squin.op`: provides the `OpType` type and semantics for operators applied to qubits.
+- `kirin.dialects.ilist`: provides the `ilist.IListType` type for lists of qubits.
+"""
+
+from typing import Any
+
+from kirin import ir, types
+from kirin.decl import info, statement
+from bloqade.types import Qubit, QubitType
+from kirin.dialects import ilist
+from kirin.lowering import wraps
+from bloqade.squin.op.types import Op, OpType
+
+dialect = ir.Dialect("squin.qubit")
+
+
+@statement(dialect=dialect)
+class New(ir.Statement):
+    traits = frozenset({ir.FromPythonCall()})
+    n_qubits: ir.SSAValue = info.argument(types.Int)
+    result: ir.ResultValue = info.result(ilist.IListType[QubitType, types.Any])
+
+    def __init__(self, n_qubits: int):
+        super().__init__(
+            attributes={"n_qubits": ir.PyAttr(n_qubits)},
+            # NOTE: we don't have dependent types in Python, this might be removed
+            #     in the future, if we end up supporting dependent types in Kirin.
+            result_types=(ilist.IListType[QubitType, types.Literal(n_qubits)],),
+        )
+
+
+@statement(dialect=dialect)
+class Apply(ir.Statement):
+    operator: ir.SSAValue = info.argument(OpType)
+    qubits: ir.SSAValue = info.argument(ilist.IListType[QubitType])
+
+
+@statement(dialect=dialect)
+class Measure(ir.Statement):
+    traits = frozenset({ir.FromPythonCall()})
+    qubits: ir.SSAValue = info.argument(ilist.IListType[QubitType])
+    result: ir.ResultValue = info.result(types.Int)
+
+
+@statement(dialect=dialect)
+class MeasureAndReset(ir.Statement):
+    traits = frozenset({ir.FromPythonCall()})
+    qubits: ir.SSAValue = info.argument(ilist.IListType[QubitType])
+    result: ir.ResultValue = info.result(types.Int)
+
+
+@statement(dialect=dialect)
+class Reset(ir.Statement):
+    qubits: ir.SSAValue = info.argument(ilist.IListType[QubitType])
+
+
+# NOTE: no dependent types in Python, so we have to mark it Any...
+@wraps(New)
+def new(n_qubits: int) -> ilist.IList[Qubit, Any]:
+    """Create a new list of qubits.
+
+    Args:
+        n_qubits(int): The number of qubits to create.
+
+    Returns:
+        (ilist.IList[Qubit, n_qubits]) A list of qubits.
+    """
+    ...
+
+
+@wraps(Apply)
+def apply(operator: Op, qubits: ilist.IList[Qubit, Any]) -> None:
+    """Apply an operator to a list of qubits.
+
+    Args:
+        operator: The operator to apply.
+        qubits: The list of qubits to apply the operator to. The size of the list
+            must be inferable and match the number of qubits expected by the operator.
+
+    Returns:
+        None
+    """
+    ...
+
+
+@wraps(Measure)
+def measure(qubits: ilist.IList[Qubit, Any]) -> int:
+    """Measure the qubits in the list."
+
+    Args:
+        qubits: The list of qubits to measure.
+
+    Returns:
+        int: The result of the measurement.
+    """
+    ...
+
+
+@wraps(MeasureAndReset)
+def measure_and_reset(qubits: ilist.IList[Qubit, Any]) -> int:
+    """Measure the qubits in the list and reset them."
+
+    Args:
+        qubits: The list of qubits to measure and reset.
+
+    Returns:
+        int: The result of the measurement.
+    """
+    ...
+
+
+@wraps(Reset)
+def reset(qubits: ilist.IList[Qubit, Any]) -> None:
+    """Reset the qubits in the list."
+
+    Args:
+        qubits: The list of qubits to reset.
+    """
+    ...

--- a/src/bloqade/squin/wire.py
+++ b/src/bloqade/squin/wire.py
@@ -1,0 +1,70 @@
+"""A NVIDIA QUAKE-like wire dialect.
+
+This dialect is expected to be used in combination with the operator dialect
+as an intermediate representation for analysis and optimization of quantum
+circuits. Thus we do not define wrapping functions for the statements in this
+dialect.
+"""
+
+from kirin import ir, types
+from kirin.decl import info, statement
+
+from .op.types import OpType
+
+dialect = ir.Dialect("squin.wire")
+
+
+class WireTerminator(ir.StmtTrait):
+    pass
+
+
+class Wire:
+    pass
+
+
+WireType = types.PyClass(Wire)
+
+
+@statement(dialect=dialect)
+class New(ir.Statement):
+    traits = frozenset({ir.FromPythonCall()})
+    result: ir.ResultValue = info.result(WireType)
+
+
+@statement(dialect=dialect)
+class Apply(ir.Statement):
+    traits = frozenset({ir.FromPythonCall(), ir.Pure()})
+    operator: ir.SSAValue = info.argument(OpType)
+    inputs: tuple[ir.SSAValue] = info.argument(WireType)
+
+    def __init__(self, operator: ir.SSAValue, *args: ir.SSAValue):
+        result_types = tuple(WireType for _ in args)
+        super().__init__(
+            args=(operator,) + args,
+            result_types=result_types,
+            args_slice={"operator": 0, "inputs": slice(1, None)},
+        )
+
+
+# NOTE: measurement cannot be pure because they will collapse the state
+#       of the qubit. The state is a hidden state that is not visible to
+#      the user in the wire dialect.
+@statement(dialect=dialect)
+class Measure(ir.Statement):
+    traits = frozenset({ir.FromPythonCall(), WireTerminator()})
+    wire: ir.SSAValue = info.argument(WireType)
+    result: ir.ResultValue = info.result(types.Int)
+
+
+@statement(dialect=dialect)
+class MeasureAndReset(ir.Statement):
+    traits = frozenset({ir.FromPythonCall(), WireTerminator()})
+    wire: ir.SSAValue = info.argument(WireType)
+    result: ir.ResultValue = info.result(types.Int)
+    out_wire: ir.ResultValue = info.result(WireType)
+
+
+@statement(dialect=dialect)
+class Reset(ir.Statement):
+    traits = frozenset({ir.FromPythonCall(), WireTerminator()})
+    wire: ir.SSAValue = info.argument(WireType)


### PR DESCRIPTION
Squin - Structural Quantum Instruction Language

This PR introduces the squin language as both an intermediate representation (IR, when combined with `wire` dialect) and a frontend language (when combined with `qubit` dialect).

## Example

```python
from bloqade.squin import kernel, qubit, op

@kernel
def main():
    qubits = qubit.new(10)
    qubit.apply(op.h(), [qubits[0]])
    qubit.apply(op.cx(), [qubits[1], qubits[2]])
    qubit.apply(op.cz(), [qubits[2], qubits[3]])
    qubit.apply(op.rot(op.x() @ op.y(), 0.5), [qubits[4]])

main.print()
```

## Motivation

### Existing languages do not consider quantum operators as an explicit object

This thus lack of the expressiveness of how operators are composed and thus how they affect the underlying gate decomposition and scheduling.

It is very common to program with quantum operators because they are fully classical. This is one of the lessons we learnt from Yao where physicists always speaks the language in operators. Traditional quantum instruction languages (e.g QASM2/3, QUAKE, etc.) prefers implementing the gates as instructions, e.g

```qasm2
cx q[1] q[0];
```

where `cx` is only a symbol (or an opcode) referencing to an instruction. However at high-level this lack the expressiveness to represent optimization results such as gate merging that is more than 1 qubit (for 1-qubit gate merges one can rely on `U(theta, phi, lambda)`), gate decomposition on general rotation (such as a Hamiltonian).

@yzcj105 provide a use case as follows

$$
(U_1 U_2 ... U_N)^\alpha U_{\lambda}
$$

where $\alpha$ is a parameter. Implementing using gate instruction

```python
def routine(q1, q2, alpha: float):
    if alpha > 0 or alpha < 0:
       gate.U_1(q1, q2)
       gate.U_2(q1, q2)
       # ...
       gate.U_N(q1, q2)
    U(q1, q2)
```

the above function when decomposing into native gate set, we need to run `N+1` gate decomposition passes, where

```python
def routine(q1, q2, alpha: float):
    gate_1 = (gate.U_1() * gate.U_2() * ... * gate.U_N())**alpha
    Apply(gate_1, q1, q2)
    gate_2 = gate.U()
    Apply(gate_2, q1, q2)
```

can have the flexibility expressing which part is merged and which part is not, where each `Apply` actually corresponding to a hardware `play` pulse statement.


### QASM2-like semantics are not friendly for dataflow analysis

QASM2-like semantics do not have return value and directly relays on the side effects of each gate (they mutates an implicit quantum state). while this could be convenient to program with, it cause a lot of problems for optimization/analysis. While we learnt the wire semantics from CUDA Q's quake dialect, we modified the semantics here to adapt to our `op` dialect.