### PR TITLE
Fixing definition of wrap/unwrap to be consistent with Nvidia

### DIFF
--- a/src/bloqade/squin/wire.py
+++ b/src/bloqade/squin/wire.py
@@ -31,7 +31,7 @@ WireType = types.PyClass(Wire)
 class Wrap(ir.Statement):
     traits = frozenset({ir.FromPythonCall(), WireTerminator()})
     wire: ir.SSAValue = info.argument(WireType)
-    qubit: ir.ResultValue = info.result(QubitType)
+    qubit: ir.SSAValue = info.argument(QubitType)
 
 
 @statement(dialect=dialect)

--- a/src/bloqade/squin/wire.py
+++ b/src/bloqade/squin/wire.py
@@ -26,18 +26,19 @@ class Wire:
 WireType = types.PyClass(Wire)
 
 
+# no return value for `wrap`
 @statement(dialect=dialect)
 class Wrap(ir.Statement):
-    traits = frozenset({ir.FromPythonCall()})
-    qubit: ir.SSAValue = info.argument(QubitType)
-    result: ir.ResultValue = info.result(WireType)
+    traits = frozenset({ir.FromPythonCall(), WireTerminator()})
+    wire: ir.SSAValue = info.argument(WireType)
+    qubit: ir.ResultValue = info.result(QubitType)
 
 
 @statement(dialect=dialect)
 class Unwrap(ir.Statement):
-    traits = frozenset({ir.FromPythonCall()})
-    wire: ir.SSAValue = info.argument(WireType)
-    result: ir.ResultValue = info.result(QubitType)
+    traits = frozenset({ir.FromPythonCall(), ir.Pure()})
+    qubit: ir.SSAValue = info.argument(QubitType)
+    result: ir.ResultValue = info.result(WireType)
 
 
 @statement(dialect=dialect)


### PR DESCRIPTION
cc: @johnzl-777 

Based on the docs of Quake: https://nvidia.github.io/cuda-quantum/latest/specification/quake-dialect.html