### PR TITLE
Updating nav bar to include Analog Reference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - QAOA: "digital/examples/qaoa.py"
   - Analog Tutorial: 'https://queracomputing.github.io/bloqade-analog-examples/dev/'
   - Bloqade Analog: 'https://queracomputing.github.io/bloqade-analog/latest/'
+  - Analog Reference: 'https://queracomputing.github.io/bloqade-analog/latest/reference/overview/'
   - Blog:
     - blog/index.md
   - QuEra Computing: 'https://quera.com'


### PR DESCRIPTION
note that this will fix this [issue](https://github.com/QuEraComputing/bloqade-analog/issues/1014) after this and https://github.com/QuEraComputing/bloqade-analog/pull/1020 are merged. 