### PR TITLE
Fix some relative path links in the docs

### DIFF
--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -27,4 +27,4 @@ The first step in Bloqade was building out the analog mode SDK, designed to inte
 
 ## Join us!
 
-If you are interested in contributing, please see the contribution page [here](quick_start/contrib.md). If you are interested in exploring more about neutral atom quantum computing, check out some analog tutorials [here](https://queracomputing.github.io/bloqade-analog-examples/dev/), and some circuit tutorials [here](https://bloqade.quera.com/latest/digital/). If you wish to work closer with QuEra, please feel free to reach out!
+If you are interested in contributing, please see the contribution page [here](contrib.md). If you are interested in exploring more about neutral atom quantum computing, check out some analog tutorials [here](https://queracomputing.github.io/bloqade-analog-examples/dev/), and some circuit tutorials [here](https://bloqade.quera.com/latest/digital/). If you wish to work closer with QuEra, please feel free to reach out!

--- a/docs/quick_start/analog/index.md
+++ b/docs/quick_start/analog/index.md
@@ -443,5 +443,5 @@ emulation_results = load("emulation_results.json")
 hardware_results = load("hardware_results.json")
 ```
 
-[local-control]: background.md#local-control
-[rydberg-hamiltonian]: background.md#rydberg-many-body-hamiltonian
+[local-control]: ../../background.md#local-control
+[rydberg-hamiltonian]: ../../background.md#rydberg-many-body-hamiltonian

--- a/docs/quick_start/circuits/index.md
+++ b/docs/quick_start/circuits/index.md
@@ -1,6 +1,6 @@
 # Digital Quantum Computing with circuits
 
-This section provides the quick start guide for developing quantum programs represented by circuits using Bloqade. Circuits are a general-purpose and powerful way of representing arbitrary computations. For a few examples please refer to our [examples](digital/index.md).
+This section provides the quick start guide for developing quantum programs represented by circuits using Bloqade. Circuits are a general-purpose and powerful way of representing arbitrary computations. For a few examples please refer to our [examples](../../digital/index.md).
 
 
 ## Open Quantum Assembly Language (QASM2) and beyond
@@ -89,7 +89,7 @@ The compilation process is divided into several stages:
 
 ### Progressive compilation
 
-As well as writing circuit executions, you can also progressively transform and compile that circuit. For example, you may want to lower arbitrary single qubit unitaries into hardware-specific unitaries, as is done in [this example](quick_start/circuits/compiler_passes/native_gate_rewrite.md). For more details on the kinds of circuit-level compiler passes and how to write your own, see [here](quick_start/circuits/compiler_passes/index.md)
+As well as writing circuit executions, you can also progressively transform and compile that circuit. For example, you may want to lower arbitrary single qubit unitaries into hardware-specific unitaries, as is done in [this example](../circuits/compiler_passes/native_gate_rewrite.md). For more details on the kinds of circuit-level compiler passes and how to write your own, see [here](../circuits/compiler_passes/index.md)
 
 ## Dialect groups
 

--- a/docs/quick_start/circuits/interpreters_and_analysis/qasm2_codegen.md
+++ b/docs/quick_start/circuits/interpreters_and_analysis/qasm2_codegen.md
@@ -16,4 +16,4 @@ ast = target.emit(main)
 pprint(ast)
 ```
 
-![QFT QASM2](qft-qasm2.png)
+![QFT QASM2](../qft-qasm2.png)


### PR DESCRIPTION
While browsing the docs (and then when running `just doc`) I found some broken links.

There's still a warning when running `just doc`:
```
WARNING -  A reference to 'quick_start/qourier/index.md' is included in the 'nav' configuration, which is not found in the documentation files.
```
But that's just due to the entry in the nav, so I ignored it for now.