### PR TITLE
Add nightly CI for documentation builds

### DIFF
--- a/.github/workflows/dev-doc-nightly.yml
+++ b/.github/workflows/dev-doc-nightly.yml
@@ -51,5 +51,7 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - name: Build documentation
+        env:
+          EXECUTE_NOTEBOOKS: "true"
         run: |
           uv run mkdocs build

--- a/.github/workflows/dev-doc-nightly.yml
+++ b/.github/workflows/dev-doc-nightly.yml
@@ -42,7 +42,20 @@ jobs:
           echo "BC_COMMIT=${{ steps.clone_bloqade_circuit.commit }}" >> $GITHUB_ENV
           echo "BA_COMMIT=${{ steps.clone_bloqade_analog.commit }}" >> $GITHUB_ENV
 
-      # TODO: check commits against previous runs and cancel if they are the same
+      - name: get previous commits from github variables
+        run: |
+          echo "BC_PREV_COMMIT=$(gh variable get DEV_DOC_NIGHTLY_BC_COMMIT)" >> $GITHUB_ENV
+          echo "BA_PREV_COMMIT=$(gh variable get DEV_DOC_NIGHTLY_BA_COMMIT)" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        
+      - name: cancel job if commits are equal
+        if: ${{ env.BC_COMMIT == env.BC_PREV_COMMIT && env.BA_COMMIT == env.BA_PREV_COMMIT }}
+        run: |
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: add local repos as dependencies
         run: uv add ../bloqade-circuit ../bloqade-analog
@@ -71,4 +84,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           git fetch origin gh-pages --depth=1
-          uv run mike deploy -p dev
+          uv run mike deploy -p dev-nightly
+
+      - name: Set variables to new commits after build
+        run: |
+          gh variable set DEV_DOC_NIGHTLY_BC_COMMIT --body "${{ env.BC_COMMIT }}"
+          gh variable set DEV_DOC_NIGHTLY_BA_COMMIT --body "${{ env.BA_COMMIT }}"
+        env:  # TODO: this may need a token with more permissions
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/dev-doc-nightly.yml
+++ b/.github/workflows/dev-doc-nightly.yml
@@ -42,15 +42,8 @@ jobs:
           echo "BC_COMMIT=${{ steps.clone_bloqade_circuit.commit }}" >> $GITHUB_ENV
           echo "BA_COMMIT=${{ steps.clone_bloqade_analog.commit }}" >> $GITHUB_ENV
 
-      - name: get previous commits from github variables
-        run: |
-          echo "BC_PREV_COMMIT=$(gh variable get DEV_DOC_NIGHTLY_BC_COMMIT)" >> $GITHUB_ENV
-          echo "BA_PREV_COMMIT=$(gh variable get DEV_DOC_NIGHTLY_BA_COMMIT)" >> $GITHUB_ENV
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        
       - name: cancel job if commits are equal
-        if: ${{ env.BC_COMMIT == env.BC_PREV_COMMIT && env.BA_COMMIT == env.BA_PREV_COMMIT }}
+        if: ${{ env.BC_COMMIT == vars.DEV_DOC_NIGHTLY_BC_COMMIT && env.BA_COMMIT == vars.DEV_DOC_NIGHTLY_BA_COMMIT }}
         run: |
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}

--- a/.github/workflows/dev-doc-nightly.yml
+++ b/.github/workflows/dev-doc-nightly.yml
@@ -1,0 +1,74 @@
+name: Documentation
+on:
+  schedule:
+  - cron: 24 4 * * *
+concurrency:
+  group: ${{ github.workflow }}-${{ github.headref }}
+  cancel-in-progress: true
+
+jobs:
+  documentation:
+    name: Deploy documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          # Install a specific version of uv.
+          version: "0.5.1"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Install Documentation dependencies
+        run: uv sync --group doc
+
+        # get latest dependencies from git directly
+      - name: clone the latest bloqade-circuit
+        id: clone_bloqade_circuit
+        uses: actions/checkout@v4
+        with:
+          repository: https://github.com/QuEraComputing/bloqade-circuit
+          path: '../bloqade-circuit'
+      
+      - name: clone the latest bloqade-analog
+        id: clone_bloqade_analog
+        uses: actions/checkout@v4
+        with:
+          repository: https://github.com/QuEraComputing/bloqade-analog
+          path: '../bloqade-analog'
+      
+      - name: assign commit hashes to variables
+        run: |
+          echo "BC_COMMIT=${{ steps.clone_bloqade_circuit.commit }}" >> $GITHUB_ENV
+          echo "BA_COMMIT=${{ steps.clone_bloqade_analog.commit }}" >> $GITHUB_ENV
+
+      # TODO: check commits against previous runs and cancel if they are the same
+
+      - name: add local repos as dependencies
+        run: uv add ../bloqade-circuit ../bloqade-analog
+        
+      - name: Set up build cache
+        uses: actions/cache@v4
+        id: cache
+        with:
+          key: mkdocs-material-nightly-dev-${{ github.headref }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - name: Depoly documentation
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          uv run mkdocs build
+      # derived from:
+      # https://github.com/RemoteCloud/public-documentation/blob/dev/.github/workflows/build_docs.yml
+      - name: Configure Git user
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+      - name: Deploy documentation
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          git fetch origin gh-pages --depth=1
+          uv run mike deploy -p dev

--- a/.github/workflows/dev-doc-nightly.yml
+++ b/.github/workflows/dev-doc-nightly.yml
@@ -1,3 +1,5 @@
+# This workflow pulls in the latest main branches of dependent packages and tries to build the documentation
+# so we can stay on top of issues with the examples when introducing changes
 name: Documentation
 on:
   schedule:
@@ -29,14 +31,14 @@ jobs:
         with:
           repository: https://github.com/QuEraComputing/bloqade-circuit
           path: '../bloqade-circuit'
-      
+
       - name: clone the latest bloqade-analog
         id: clone_bloqade_analog
         uses: actions/checkout@v4
         with:
           repository: https://github.com/QuEraComputing/bloqade-analog
           path: '../bloqade-analog'
-      
+
       - name: assign commit hashes to variables
         run: |
           echo "BC_COMMIT=${{ steps.clone_bloqade_circuit.commit }}" >> $GITHUB_ENV
@@ -52,7 +54,7 @@ jobs:
 
       - name: add local repos as dependencies
         run: uv add ../bloqade-circuit ../bloqade-analog
-        
+
       - name: Set up build cache
         uses: actions/cache@v4
         id: cache

--- a/.github/workflows/dev-doc-nightly.yml
+++ b/.github/workflows/dev-doc-nightly.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   documentation:
-    name: Deploy documentation
+    name: Build documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,19 +39,6 @@ jobs:
           repository: https://github.com/QuEraComputing/bloqade-analog
           path: '../bloqade-analog'
 
-      - name: assign commit hashes to variables
-        run: |
-          echo "BC_COMMIT=${{ steps.clone_bloqade_circuit.commit }}" >> $GITHUB_ENV
-          echo "BA_COMMIT=${{ steps.clone_bloqade_analog.commit }}" >> $GITHUB_ENV
-
-      - name: cancel job if commits are equal
-        if: ${{ env.BC_COMMIT == vars.DEV_DOC_NIGHTLY_BC_COMMIT && env.BA_COMMIT == vars.DEV_DOC_NIGHTLY_BA_COMMIT }}
-        run: |
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
       - name: add local repos as dependencies
         run: uv add ../bloqade-circuit ../bloqade-analog
 
@@ -63,27 +50,6 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - name: Depoly documentation
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Build documentation
         run: |
           uv run mkdocs build
-      # derived from:
-      # https://github.com/RemoteCloud/public-documentation/blob/dev/.github/workflows/build_docs.yml
-      - name: Configure Git user
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-      - name: Deploy documentation
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          git fetch origin gh-pages --depth=1
-          uv run mike deploy -p dev-nightly
-
-      - name: Set variables to new commits after build
-        run: |
-          gh variable set DEV_DOC_NIGHTLY_BC_COMMIT --body "${{ env.BC_COMMIT }}"
-          gh variable set DEV_DOC_NIGHTLY_BA_COMMIT --body "${{ env.BA_COMMIT }}"
-        env:  # TODO: this may need a token with more permissions
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/doc-nightly.yml
+++ b/.github/workflows/doc-nightly.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   documentation:
-    name: Deploy documentation
+    name: Build documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-
       - name: Set up build cache
         uses: actions/cache@v4
         id: cache
@@ -46,19 +45,6 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - name: Depoly documentation
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Build documentation
         run: |
           uv run mkdocs build
-      - name: Deploy docs
-        uses: rossjrw/pr-preview-action@v1
-        with:
-          source-dir: ./site
-
-      - name: Set variables to new versions after build
-        run: |
-          gh variable set DOC_NIGHTLY_BC_VERSION --body "${{ env.BC_VERSION }}"
-          gh variable set DOC_NIGHTLY_BA_VERSION --body "${{ env.BA_VERSION }}"
-        env:  # TODO: this may need a token with more permissions
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/doc-nightly.yml
+++ b/.github/workflows/doc-nightly.yml
@@ -3,7 +3,7 @@
 name: Documentation
 on:
   schedule:
-  - cron: 12 4 * * *
+  - cron: 12 4 * * 0
 concurrency:
   group: ${{ github.workflow }}-${{ github.headref }}
   cancel-in-progress: true
@@ -23,19 +23,6 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - name: Install Documentation dependencies
         run: uv sync --group doc
-
-      - name: get bloqade sub-package versions
-        run: |
-          echo "BC_VERSION=$(uv pip show bloqade-circuit | grep Version)" >> $GITHUB_ENV
-          echo "BA_VERSION=$(uv pip show bloqade-analog | grep Version)" >> $GITHUB_ENV
-
-      - name: cancel job if version are equal
-        if: ${{ env.BC_VERSION == vars.DOC_NIGHTLY_BC_VERSION && env.BA_VERSION == vars.DOC_NIGHTLY_BA_VERSION }}
-        run: |
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Set up build cache
         uses: actions/cache@v4

--- a/.github/workflows/doc-nightly.yml
+++ b/.github/workflows/doc-nightly.yml
@@ -1,0 +1,36 @@
+name: Documentation
+on:
+  schedule:
+  - cron: 12 4 * * *
+concurrency:
+  group: ${{ github.workflow }}-${{ github.headref }}-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  documentation:
+    name: Deploy documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          # Install a specific version of uv.
+          version: "0.5.1"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Install Documentation dependencies
+        run: uv sync --group doc
+      - name: Set up build cache
+        uses: actions/cache@v4
+        id: cache
+        with:
+          key: mkdocs-material-${{ github.ref }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - name: Depoly documentation
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          uv run mkdocs build

--- a/.github/workflows/doc-nightly.yml
+++ b/.github/workflows/doc-nightly.yml
@@ -3,7 +3,7 @@ on:
   schedule:
   - cron: 12 4 * * *
 concurrency:
-  group: ${{ github.workflow }}-${{ github.headref }}-${{ github.sha }}
+  group: ${{ github.workflow }}-${{ github.headref }}
   cancel-in-progress: true
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v4
         id: cache
         with:
-          key: mkdocs-material-${{ github.ref }}
+          key: mkdocs-material-nigthly-${{ github.headref }}
           path: .cache
           restore-keys: |
             mkdocs-material-

--- a/.github/workflows/doc-nightly.yml
+++ b/.github/workflows/doc-nightly.yml
@@ -34,3 +34,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           uv run mkdocs build
+      - name: Deploy docs
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site

--- a/.github/workflows/doc-nightly.yml
+++ b/.github/workflows/doc-nightly.yml
@@ -1,3 +1,5 @@
+# This workflow builds & deploys the documentation using the latest release versions of dependent packages
+# Main use is to detect issues / accidental breaking changes with patch releases of e.g. bloqade-circuit
 name: Documentation
 on:
   schedule:
@@ -40,7 +42,7 @@ jobs:
         uses: actions/cache@v4
         id: cache
         with:
-          key: mkdocs-material-nigthly-${{ github.headref }}
+          key: mkdocs-material-nightly-${{ github.headref }}
           path: .cache
           restore-keys: |
             mkdocs-material-

--- a/.github/workflows/doc-nightly.yml
+++ b/.github/workflows/doc-nightly.yml
@@ -46,5 +46,7 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - name: Build documentation
+        env:
+          EXECUTE_NOTEBOOKS: "true"
         run: |
           uv run mkdocs build

--- a/.github/workflows/doc-nightly.yml
+++ b/.github/workflows/doc-nightly.yml
@@ -21,6 +21,21 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - name: Install Documentation dependencies
         run: uv sync --group doc
+
+      - name: get bloqade sub-package versions
+        run: |
+          echo "BC_VERSION=$(uv pip show bloqade-circuit | grep Version)" >> $GITHUB_ENV
+          echo "BA_VERSION=$(uv pip show bloqade-analog | grep Version)" >> $GITHUB_ENV
+
+      - name: cancel job if version are equal
+        if: ${{ env.BC_VERSION == vars.DOC_NIGHTLY_BC_VERSION && env.BA_VERSION == vars.DOC_NIGHTLY_BA_VERSION }}
+        run: |
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+
       - name: Set up build cache
         uses: actions/cache@v4
         id: cache
@@ -38,3 +53,10 @@ jobs:
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./site
+
+      - name: Set variables to new versions after build
+        run: |
+          gh variable set DOC_NIGHTLY_BC_VERSION --body "${{ env.BC_VERSION }}"
+          gh variable set DOC_NIGHTLY_BA_VERSION --body "${{ env.BA_VERSION }}"
+        env:  # TODO: this may need a token with more permissions
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/_typos.toml
+++ b/_typos.toml
@@ -12,3 +12,6 @@ AttributeIDSupressMenu = "AttributeIDSupressMenu"
 Braket = "Braket"
 mch = "mch"
 IY = "IY"
+
+[files]
+extend-exclude = [".github/workflows/*"]

--- a/justfile
+++ b/justfile
@@ -15,8 +15,9 @@ coverage-open:
 
 coverage: coverage-run coverage-xml coverage-report
 
-doc:
-    mkdocs serve
+doc FLAGS="":
+    mkdocs serve {{FLAGS}}
 
-doc-build:
-    mkdocs build
+doc-build FLAGS="":
+    mkdocs build {{FLAGS}}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,7 +144,7 @@ plugins:
       minify_html: false
   - blog
   - mkdocs-jupyter:
-      execute: !ENV ["EXECUTE_NOTEBOOKS", true]
+      execute: !ENV ["EXECUTE_NOTEBOOKS", false]
       allow_errors: false
       ignore: ["scripts/*"]
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,7 +144,7 @@ plugins:
       minify_html: false
   - blog
   - mkdocs-jupyter:
-      execute: !ENV ["EXECUTE_NOTEBOOKS", false]
+      execute: !ENV ["EXECUTE_NOTEBOOKS", true]
       allow_errors: false
       ignore: ["scripts/*"]
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,7 +146,10 @@ plugins:
   - mkdocs-jupyter:
       execute: !ENV ["EXECUTE_NOTEBOOKS", true]
       allow_errors: false
+<<<<<<< HEAD
       ignore: ["scripts/*"]
+=======
+>>>>>>> f8677ffc (Add nightly release doc build workflow)
 
 extra_javascript:
   - javascripts/katex.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,10 +146,7 @@ plugins:
   - mkdocs-jupyter:
       execute: !ENV ["EXECUTE_NOTEBOOKS", true]
       allow_errors: false
-<<<<<<< HEAD
       ignore: ["scripts/*"]
-=======
->>>>>>> f8677ffc (Add nightly release doc build workflow)
 
 extra_javascript:
   - javascripts/katex.js


### PR DESCRIPTION
Closes #228 and possibly also #219 

Needs a release of bloqade-circuit v0.2.0 first as it also updates the examples to work with the new version.

Also, I'm checking the versions / commit hashes for the nightly builds and cancel the jobs if nothing has changed. To do this, I'm using github variables. Not sure if this is the best solution. If it is, then we'd need to create the variables (the body can be empty to start with). There are probably permission issues then as well since I don't think the `GH_TOKEN` has permissions to set github variables and cancel jobs.

@Roger-luo @weinbe58 do you know a better solution for this?
