### PR TITLE
Update docs to bloqade-circuit v0.2

### DIFF
--- a/docs/digital/examples/qaoa.py
+++ b/docs/digital/examples/qaoa.py
@@ -9,8 +9,9 @@ from typing import Any
 
 import kirin
 import networkx as nx
+from kirin.dialects import ilist
+
 from bloqade import qasm2
-from kirin.dialects import py, ilist
 
 pi = math.pi
 

--- a/docs/digital/examples/qaoa.py
+++ b/docs/digital/examples/qaoa.py
@@ -47,9 +47,9 @@ def qaoa_sequential(G: nx.Graph) -> kirin.ir.Method:
     @qasm2.extended
     def kernel(gamma: ilist.IList[float, Any], beta: ilist.IList[float, Any]):
         # Initialize the register in the |+> state
-        qreg = qasm2.qreg(N)
+        q = qasm2.qreg(N)
         for i in range(N):  # structural control flow is native to the Kirin compiler
-            qasm2.h(qreg[i])
+            qasm2.h(q[i])
 
         # Repeat the cost and mixer layers
         for i in range(len(gamma)):
@@ -57,15 +57,15 @@ def qaoa_sequential(G: nx.Graph) -> kirin.ir.Method:
             # to each edge of the graph
             for j in range(len(edges)):
                 edge = edges[j]
-                qasm2.cx(qreg[edge[0]], qreg[edge[1]])
-                qasm2.rz(qreg[edge[1]], gamma[i])
-                qasm2.cx(qreg[edge[0]], qreg[edge[1]])
+                qasm2.cx(q[edge[0]], q[edge[1]])
+                qasm2.rz(q[edge[1]], gamma[i])
+                qasm2.cx(q[edge[0]], q[edge[1]])
             # The mixer layer, which corresponds to a X(phase) gate applied
             # to each node of the graph
             for j in range(N):
-                qasm2.rx(qreg[j], beta[i])
+                qasm2.rx(q[j], beta[i])
 
-        return qreg
+        return q
 
     return kernel
 
@@ -136,11 +136,11 @@ def qaoa_simd(G: nx.Graph) -> kirin.ir.Method:
     @qasm2.extended
     def kernel(gamma: ilist.IList[float, Any], beta: ilist.IList[float, Any]):
         # Declare the register and set it to the |+> state
-        qreg = qasm2.qreg(len(nodes))
-        # qasm2.glob.u(theta=pi / 2, phi=0.0, lam=pi,registers=[qreg])
+        q = qasm2.qreg(len(nodes))
+        # qasm2.glob.u(theta=pi / 2, phi=0.0, lam=pi,registers=[q])
 
         def get_qubit(x: int):
-            return qreg[x]
+            return q[x]
 
         all_qubits = ilist.map(fn=get_qubit, collection=range(N))
 
@@ -157,10 +157,10 @@ def qaoa_simd(G: nx.Graph) -> kirin.ir.Method:
             # ...then, do an X phase gate. Observe that because this happens on every
             # qubit, we can do a global rotation, which is higher fidelity than
             # parallel local rotations.
-            # qasm2.glob.u(theta=beta[i],phi=0.0,lam=0.0,registers=[qreg])
+            # qasm2.glob.u(theta=beta[i],phi=0.0,lam=0.0,registers=[q])
             qasm2.parallel.u(qargs=all_qubits, theta=beta[i], phi=0.0, lam=0.0)
 
-        return qreg
+        return q
 
     return kernel
 
@@ -183,10 +183,6 @@ def main():
 
 
 # %%
-target = qasm2.emit.QASM2(
-    main_target=qasm2.main.union(
-        [qasm2.dialects.parallel, qasm2.dialects.glob, ilist, py.constant]
-    )
-)
+target = qasm2.emit.QASM2()
 ast = target.emit(main)
 qasm2.parse.pprint(ast)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,8 +128,9 @@ plugins:
       minify_html: false
   - blog
   - mkdocs-jupyter:
-      #include: ["examples/ghz.py"]
-      #ignore: []
+      execute: !ENV ["EXECUTE_NOTEBOOKS", false]
+      allow_errors: false
+      ignore: ["scripts/*"]
 
 extra_javascript:
   - javascripts/katex.js

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "bloqade-circuit[cirq,qasm2,qbraid,vis]~=0.1.0",
+    "bloqade-circuit[cirq,qasm2,qbraid,vis]~=0.2.0",
     "bloqade-analog~=0.16.3",
 ]
 


### PR DESCRIPTION
@Roger-luo I'm taking the liberty to skip review here, since I'm really just fixing an example to work with bloqade-circuit v0.2.0.

Here are the changes:
* The QAOA example used `qreg` as a variable, which is a reserved name, so I changed it.
* You can now run `EXECUTE_NOTEBOOKS="true" just doc` in order to execute notebooks when building the docs. Due to issues with `pprint` the default is `false` so there won't be any output in the docs.
* Updates the dependency to bloqade-circuit v0.2.0.