### PR TITLE
Include full API reference in the docs

### DIFF
--- a/docs/digital/dialects_and_kernels.md
+++ b/docs/digital/dialects_and_kernels.md
@@ -1,0 +1,174 @@
+# Dialects and kernels
+
+!!! info
+    A **kernel** function is a piece of code that runs on specialized hardware such as a quantum computer.
+
+    A **dialect** is a domain-specific language (DSL) with which you can write such a kernel.
+    Each dialect comes with a specific set of statements and instructions you can use in order to write your program.
+
+Bloqade provides a set of pre-defined dialects, with which you can write your programs and circuits.
+
+Once you have your kernel, you can inspect their intermediate representation (IR), apply different optimizations using [compiler passes](../quick_start/circuits/compiler_passes/index.md), or run them on a [(simulator) device](./simulator_device/simulator_device.md).
+
+
+# Available dialects
+
+Here's a quick overview of the most important available dialects.
+
+## qasm2
+
+There are a number of dialects with which you can write kernels that represent QASM2 programs.
+See also the [qasm2 API reference](../reference/qasm2.md)
+
+### qasm2.main
+
+This dialect allows you to write native QASM2 programs.
+As such, it includes definitions gates, measurements and quantum and classical registers, which are part of the QASM2 specification.
+For details on the language, see the [specification](https://arxiv.org/abs/1707.03429).
+
+Here's an example kernel
+
+```python
+from bloqade import qasm2
+
+@qasm2.main
+def main():
+    q = qasm2.qreg(2)
+    qasm2.h(q[0])
+    qasm2.cx(q[0], q[1])
+
+    c = qasm2.creg(2)
+    qasm2.measure(q, c)
+    return c
+```
+
+Here's how you can look at the QASM2 program this kernel represents:
+
+```python
+from bloqade.qasm2.emit import QASM2
+from bloqade.qasm2.parse import pprint
+
+
+target = QASM2()
+qasm2_program = target.emit(main)
+pprint(qasm2_program)
+```
+
+### qasm2.extended
+
+This dialect can also be used to write QASM2 programs.
+However, it adds a couple of statements that makes it easier to write programs.
+For example, QASM2 does not support for-loops.
+With `qasm2.extended`, however, you can use for-loops and can let the compiler worry about unrolling these loops such that valid QASM2 code is produced.
+
+```python
+from bloqade import qasm2
+
+@qasm2.extended
+def main():
+    n = 2
+    q = qasm2.qreg(n)
+
+    for i in range(n):
+        qasm2.h(q[i])
+
+    qasm2.cx(q[0], q[1])
+    c = qasm2.creg(n)
+    qasm2.measure(q, c)
+    return c
+```
+
+If you run this through the code emission as shown above, you'll see that the for-loop gets unrolled into separate hadamard gate applications for each qubit.
+At the same time, if you try to define this kernel using the `qasm2.main` dialect only, you will receive a `BuildError` telling you to take that crazy for-loop out of there as it's not supported.
+
+
+## noise.native
+
+Using this dialect, you can represent different noise processes in your kernel.
+As of now, there are essentially two different noise channels:
+
+* A pauli noise channel, which can represent different types of decoherence.
+* An atomic loss channel, which can be used to model effects of losing a qubit during the execution of a program.
+
+Usually, you don't want to write noise statements directly.
+Instead, use a [NoisePass][bloqade.qasm2.passes.NoisePass] in order to inject noise statements automatically according to a specific noise model.
+
+!!! note
+    Right now, only the `qasm2` dialects fully support noise.
+
+For example, you may want to do something like this:
+
+```python
+from bloqade import qasm2
+from bloqade.noise import native
+from bloqade.qasm2.passes import NoisePass
+
+
+# Add the noise dialect to qasm2.extended
+noise_dialect = qasm2.extended.add(native.dialect)
+
+@noise_dialect
+def main():
+    n = 2
+    q = qasm2.qreg(n)
+
+    for i in range(n):
+        qasm2.h(q[i])
+
+    qasm2.cx(q[0], q[1])
+    c = qasm2.creg(n)
+    qasm2.measure(q, c)
+    return c
+
+# Define the noise pass you want to use
+noise_pass = NoisePass(main.dialects)  # just use the default noise model for now
+
+# Inject the noise - note that the main method will be updated in-place
+noise_pass.unsafe_run(main)
+
+# Look at the IR and all the glorious noise in there
+main.print()
+```
+
+
+## squin
+
+This dialect is, in a sense, more expressive than the qasm2 dialects: it allows you to specify operators rather than just gate applications.
+That can be useful if you're trying to e.g. simulate a Hamiltonian time evolution.
+
+!!! warning
+    The squin dialect is in an early stage of development.
+    Expect substantial changes to it in the near future.
+
+Here's a short example:
+
+```python
+from bloqade import squin
+
+@squin.kernel
+def main():
+    q = squin.qubit.new(2)
+    h = squin.op.h()
+
+    # apply a hadamard to only the first qubit
+    h1 = squin.op.kron(h, squin.op.identity(sites=1))
+
+    squin.qubit.apply(h1, q)
+
+    cx = squin.op.cx()
+    squin.qubit.apply(cx, q)
+
+    return squin.qubit.measure(q)
+
+# have a look at the IR
+main.print()
+```
+
+See also the [squin API reference](../reference/squin.md)
+
+## stim
+
+!!! warning
+    Sorry folks, still under construction.
+
+See also the [stim API reference](../reference/stim.md)

--- a/docs/digital/index.md
+++ b/docs/digital/index.md
@@ -6,8 +6,8 @@
 
 # Digital Bloqade
 
-This page provides a collection of quick examples to help you get started with Digital Bloqade. Each
-example is a self-contained page that demonstrates a specific feature or use case. You can copy and
-paste the code snippets into your own project and modify them as needed.
+This page provides some information on digital circuits, their simulation and a collection of quick examples to help you get started with Digital Bloqade.
+Each example is a self-contained page that demonstrates a specific feature or use case.
+You can copy and paste the code snippets into your own project and modify them as needed.
 
 You can also find the corresponding scripts in [jupytext format](https://jupytext.readthedocs.io/en/latest/) at the [bloqade repository](https://github.com/QuEraComputing/bloqade) under `docs/digital/examples/`.

--- a/docs/digital/simulator_device/simulator_device.md
+++ b/docs/digital/simulator_device/simulator_device.md
@@ -1,0 +1,27 @@
+# Simulation devices
+
+A simulation device can run a [task](./tasks.md), such as executing a kernel.
+It acts just like a device that is an actual hardware, but runs everything in a local simulation.
+As such, it can also be used to inspect the results of your program beyond what is possible on a QPU.
+For example, you can return the `state_vector` of the quantum register at the end of the task execution.
+
+Here's how you can use it in order to run a simple `qasm2.extended` kernel.
+
+```python
+from bloqade.pyqrack import StackMemorySimulator
+from bloqade import qasm2
+
+@qasm2.extended
+def main():
+    q = qasm2.qreg(2)
+
+    qasm2.h(q[0])
+    qasm2.cx(q[0], q[1])
+
+    return q
+
+sim = StackMemorySimulator(min_qubits=2)
+
+# get the state vector -- oohh entanglement
+state = sim.state_vector(main)
+```

--- a/docs/digital/simulator_device/tasks.md
+++ b/docs/digital/simulator_device/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+!!! warning
+    Sorry folks, still under construction.
+
+For now, please check the [API reference](../../reference/task.md).

--- a/docs/reference/analog.md
+++ b/docs/reference/analog.md
@@ -1,0 +1,7 @@
+---
+title: analog
+---
+
+# ::: bloqade.analog
+    options:
+        show_submodules: true

--- a/docs/reference/analysis.md
+++ b/docs/reference/analysis.md
@@ -1,0 +1,7 @@
+---
+title: analysis
+---
+
+# ::: bloqade.analysis
+    options:
+        show_submodules: true

--- a/docs/reference/device.md
+++ b/docs/reference/device.md
@@ -1,0 +1,7 @@
+---
+title: device
+---
+
+# ::: bloqade.device
+    options:
+        show_submodules: true

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,6 @@
+---
+title: API Reference
+---
+
+Use the navigation on the left to browse the full API reference of the bloqade package.
+The documentation is separated into all submodules of bloqade.

--- a/docs/reference/noise.md
+++ b/docs/reference/noise.md
@@ -1,0 +1,7 @@
+---
+title: noise
+---
+
+# ::: bloqade.noise
+    options:
+        show_submodules: true

--- a/docs/reference/pyqrack.md
+++ b/docs/reference/pyqrack.md
@@ -1,0 +1,7 @@
+---
+title: pyqrack
+---
+
+# ::: bloqade.pyqrack
+    options:
+        show_submodules: true

--- a/docs/reference/qasm2.md
+++ b/docs/reference/qasm2.md
@@ -1,0 +1,7 @@
+---
+title: qasm2
+---
+
+# ::: bloqade.qasm2
+    options:
+        show_submodules: true

--- a/docs/reference/qbraid.md
+++ b/docs/reference/qbraid.md
@@ -1,0 +1,7 @@
+---
+title: qbraid
+---
+
+# ::: bloqade.qbraid
+    options:
+        show_submodules: true

--- a/docs/reference/squin.md
+++ b/docs/reference/squin.md
@@ -1,0 +1,7 @@
+---
+title: squin
+---
+
+# ::: bloqade.squin
+    options:
+        show_submodules: true

--- a/docs/reference/stim.md
+++ b/docs/reference/stim.md
@@ -1,5 +1,5 @@
 ---
-title: Sstim
+title: stim
 ---
 
 # ::: bloqade.stim

--- a/docs/reference/stim.md
+++ b/docs/reference/stim.md
@@ -1,0 +1,7 @@
+---
+title: Sstim
+---
+
+# ::: bloqade.stim
+    options:
+        show_submodules: true

--- a/docs/reference/task.md
+++ b/docs/reference/task.md
@@ -1,0 +1,7 @@
+---
+title: task
+---
+
+# ::: bloqade.task
+    options:
+        show_submodules: true

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -1,0 +1,7 @@
+---
+title: types
+---
+
+# ::: bloqade.types
+    options:
+        show_submodules: true

--- a/docs/reference/visual.md
+++ b/docs/reference/visual.md
@@ -1,0 +1,7 @@
+---
+title: visual
+---
+
+# ::: bloqade.visual
+    options:
+        show_submodules: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,10 +52,23 @@ nav:
   - Analog Tutorials: 'https://queracomputing.github.io/bloqade-analog-examples/dev/'
   - Bloqade Analog: 'https://queracomputing.github.io/bloqade-analog/latest/'
   - Analog Reference: 'https://queracomputing.github.io/bloqade-analog/latest/reference/overview/'
+  - API Reference:
+    - reference/index.md
+    - reference/analog.md
+    - reference/analysis.md
+    - reference/device.md
+    - reference/noise.md
+    - reference/pyqrack.md
+    - reference/qasm2.md
+    - reference/qbraid.md
+    - reference/squin.md
+    - reference/stim.md
+    - reference/task.md
+    - reference/types.md
+    - reference/visual.md
   - Blog:
     - blog/index.md
   - QuEra Computing: 'https://quera.com'
-  # - API Reference:
   #     - QASM2: reference/bloqade/qasm2/
 
 theme:
@@ -104,7 +117,6 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          paths: [src]
           options:
             show_if_no_docstring: false
             separate_signature: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,10 @@ nav:
       - Contributing: contrib.md
   - Digital Tutorials:
     - digital/index.md
+    - digital/dialects_and_kernels.md
+    - Simulator Device:
+      - digital/simulator_device/simulator_device.md
+      - digital/simulator_device/tasks.md
     - Circuits:
       - Quantum Fourier Transform: "digital/examples/qft.py"
       - GHZ state preparation: "digital/examples/ghz.py"


### PR DESCRIPTION
I split things up by submodules, i.e. there's one page for each entry in `bloqade.*`. The disadvantage is that new modules won't be added automatically. However, putting everything on a single page is not really feasible. I couldn't find a better way for now.