### PR TITLE
Pull submodules when publishing release docs

### DIFF
--- a/.github/workflows/pub_doc.yml
+++ b/.github/workflows/pub_doc.yml
@@ -25,6 +25,10 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - name: Install Documentation dependencies
         run: uv sync --group doc
+
+      - name: Pull bloqade submodules
+        uses: ./.github/pull_bloqade_submodules
+
       - name: Set up build cache
         uses: actions/cache@v4
         id: cache


### PR DESCRIPTION
I'm not 100% certain this fixes things, but judging from the output here https://github.com/QuEraComputing/bloqade/actions/runs/17265060758/job/48995143154#logs it seems to me that the submodule repos are just missing during the build which results in no API reference being published.