### PR TITLE
Dedicated landing page for API reference

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,9 @@
+# API Reference
+
+Here you can find a full API reference grouped by the respective submodules of bloqade:
+
+* [`bloqade-circuit`](./bloqade-circuit/src/bloqade/types)
+* [`bloqade-analog`](./bloqade-analog/src/bloqade/analog/)
+
+Please note that the reference is auto-generated and therefore follows the structure of the code.
+You can use the navigation on the left to browse through the full API reference or use the search functionality.

--- a/docs/scripts/gen_ref_nav.py
+++ b/docs/scripts/gen_ref_nav.py
@@ -38,6 +38,7 @@ skip_keywords = [
     "tests/",
     "test_utils",
     "docs/",
+    "debug/",
     "squin/cirq/emit/",  # NOTE: this fails when included because there is an __init__.py missing, but the files have no docs anyway and it will be moved so safe to ignore
 ]
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
   - Analog Tutorials: 'https://queracomputing.github.io/bloqade-analog-examples/dev/'
   - qBook: 'https://qbook.quera.com/'
   - API Reference:
+    - 'reference/index.md'
     - Bloqade Digital: 'reference/bloqade-circuit/src/bloqade/'
     - Bloqade Analog: 'reference/bloqade-analog/src/bloqade/analog/'
   - Blog:


### PR DESCRIPTION
As @jon-wurtz pointed out, having bloqade-circuit/device as landing page is not ideal since it's not really that relevant.

This PR adds a dedicated landing page for the API reference. It's pretty basic right now, but we could potentially add a hand-written, more readable overview to it in the future. That would give us the benefit of having a more approachable overview of the API and keeping the full auto-generated API reference on top of that.