### PR TITLE
Update documentation to match the upcoming SQUIN refactor

### DIFF
--- a/docs/digital/examples/squin/deutsch_squin.py
+++ b/docs/digital/examples/squin/deutsch_squin.py
@@ -42,7 +42,7 @@ n_bits = 2
 @squin.kernel
 def f_constant(q: ilist.IList[Qubit, Any]):
     # flip the final (result) qubit -- every bit string is mapped to 1
-    squin.gate.x(q[-1])
+    squin.x(q[-1])
 
 
 # %% [markdown]
@@ -54,7 +54,7 @@ def f_constant(q: ilist.IList[Qubit, Any]):
 # %%
 @squin.kernel
 def f_balanced(q: ilist.IList[Qubit, Any]):
-    squin.gate.cx(q[0], q[-1])
+    squin.cx(q[0], q[-1])
 
 
 # %% [markdown]
@@ -65,16 +65,15 @@ def f_balanced(q: ilist.IList[Qubit, Any]):
 @squin.kernel
 def deutsch_algorithm(f):
     q = squin.qubit.new(n_qubits=n_bits + 1)
-    squin.gate.x(q[-1])
+    squin.x(q[-1])
 
     # broadcast for parallelism
-    h = squin.op.h()
-    squin.qubit.broadcast(h, q)
+    squin.broadcast.h(q)
 
     # apply the oracle function
     f(q)
 
-    squin.qubit.broadcast(h, q[:-1])
+    squin.broadcast.h(q[:-1])
 
     return squin.qubit.measure(q[:-1])
 

--- a/docs/digital/examples/squin/ghz.py
+++ b/docs/digital/examples/squin/ghz.py
@@ -26,9 +26,6 @@
 # ![GHZ linear circuit](../../ghz_linear_circuit.svg)
 
 # %% [markdown]
-# Since this circuit is rather simple, we can stick to the Squin standard library in order to implement it.
-# The gates are defined in the `squin.gate` submodule.
-#
 # Let's start by importing Squin and writing our circuit for an arbitrary number of qubits.
 
 # %%
@@ -40,9 +37,9 @@ from bloqade import squin
 @squin.kernel
 def ghz_linear(n: int):
     q = squin.qubit.new(n)
-    squin.gate.h(q[0])
+    squin.h(q[0])
     for i in range(1, n):
-        squin.gate.cx(q[i - 1], q[i])
+        squin.cx(q[i - 1], q[i])
 
 
 ghz_linear.print()
@@ -114,18 +111,12 @@ print(sim.state_vector(ghz_linear, args=(2,)))
 def noisy_linear_ghz(n: int, p_single: float, p_paired: float):
     q = squin.qubit.new(n)
 
-    # define the noise operator for the single qubit
-    single_qubit_noise = squin.noise.depolarize(p_single)
-
-    squin.gate.h(q[0])
-    squin.qubit.apply(single_qubit_noise, q[0])
-
-    # pair qubit noise operator
-    two_qubit_noise = squin.noise.depolarize2(p_paired)
+    squin.h(q[0])
+    squin.depolarize(p_single, q[0])
 
     for i in range(1, n):
-        squin.gate.cx(q[i - 1], q[i])
-        squin.qubit.apply(two_qubit_noise, q[i - 1], q[i])
+        squin.cx(q[i - 1], q[i])
+        squin.depolarize2(p_paired, q[i - 1], q[i])
 
     return squin.qubit.measure(q)
 


### PR DESCRIPTION
FYI, @jon-wurtz I updated the tutorial you wrote in order to match the new semantics. Something to keep in mind while working on coming tutorials.

Also, we need to support lowering of `cirq.ZZPowGate` or, equivalently, `cirq.CZPowGate` for arbitrary exponents again, which is something I still need to address.

Still need to rewrite the actual documentation pages.