### PR TITLE
Allow disabling notebook execution for local builds

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,7 +135,7 @@ plugins:
   - blog:
       post_excerpt_max_authors: 5
   - mkdocs-jupyter:
-      execute: true
+      execute: !ENV ["EXECUTE_NOTEBOOKS", true]
       allow_errors: false
       execute_ignore: ["scripts/*", "digital/examples/qasm2/*"]
   - mike


### PR DESCRIPTION
So you can run

```bash
EXECUTE_NOTEBOOKS="false" just doc
```

in order to avoid execution.