### PR TITLE
test: confirm Amplify PR preview fires (throwaway)

### DIFF
--- a/.amplify-preview-test.md
+++ b/.amplify-preview-test.md
@@ -1,0 +1,5 @@
+# Amplify preview smoke test
+
+Throwaway file to trigger an Amplify PR preview build for a PR targeting
+`astro-docs`. Safe to delete — this branch and PR will be torn down once the
+preview is confirmed.


### PR DESCRIPTION
Throwaway PR to verify AWS Amplify generates a per-PR preview for PRs targeting `astro-docs`. Will be closed and the branch deleted once confirmed.