### PR TITLE
Bump bloqade-circuit to 0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "bloqade-circuit[cirq,qasm2,qbraid,vis,stim]~=0.14.1",
+    "bloqade-circuit[cirq,qasm2,qbraid,vis,stim]~=0.15.0",
     "bloqade-analog~=0.16.3",
     "bloqade-lanes~=0.10.6",
     "bloqade-tsim~=0.1.4",


### PR DESCRIPTION
Follows the `bloqade-circuit` 0.15.0 release (now live on PyPI). Updates the
`bloqade-circuit` version constraint. CI will surface any breakage.

Note: `uv.lock` was intentionally **not** regenerated in this PR. Re-locking here
either fails or produces large unrelated churn because it needs the internal
package index and prerelease settings that are only available in CI / a
maintainer's environment. Please refresh the lockfile before merging.

Opened as part of the coordinated bloqade-circuit 0.15.0 ecosystem release.
