### PR TITLE
docs: deploy to GitHub Pages project URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/QuEraComputing/bloqade/actions/workflows/ci.yml/badge.svg)](https://github.com/QuEraComputing/bloqade/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/QuEraComputing/bloqade/graph/badge.svg?token=BpHsAYuzdo)](https://codecov.io/gh/QuEraComputing/bloqade)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/bloqade.svg?color=%2334D058)](https://pypi.org/project/bloqade)
-[![Documentation](https://img.shields.io/badge/Documentation-6437FF)](https://bloqade.quera.com/)
+[![Documentation](https://img.shields.io/badge/Documentation-6437FF)](https://queracomputing.github.io/bloqade/)
 [![DOI](https://zenodo.org/badge/629628885.svg)](https://zenodo.org/doi/10.5281/zenodo.11114109)
 
 
@@ -23,11 +23,11 @@ uv add bloqade
 
 ## Documentation
 
-The documentation is available at [https://bloqade.quera.com/latest/](https://bloqade.quera.com/latest/). We are at an early stage of completing the documentation with more details and examples, so comments and contributions are most welcome!
+The documentation is available at [https://queracomputing.github.io/bloqade/latest/](https://queracomputing.github.io/bloqade/latest/). We are at an early stage of completing the documentation with more details and examples, so comments and contributions are most welcome!
 
 ## Contributing
 
-We welcome contributions! Please check the [contribution guidelines](https://bloqade.quera.com/latest/contrib/) for a detailed guide.
+We welcome contributions! Please check the [contribution guidelines](https://queracomputing.github.io/bloqade/latest/contrib/) for a detailed guide.
 
 > [!NOTE]
 >

--- a/docs/blog/posts/2025/the-noise-strikes-back.md
+++ b/docs/blog/posts/2025/the-noise-strikes-back.md
@@ -86,7 +86,7 @@ It is often most convenient to study an example in order to learn how to use a s
 To this end, we included a tutorial that shows how to annotate a GHZ preparation circuit using the different
 heuristic noise models.
 We'll discuss some underlying concepts and highlight interesting parts of the tutorial in this section.
-If you want all the details, please find [the full example here](https://bloqade.quera.com/latest/digital/examples/interop/noisy_ghz/).
+If you want all the details, please find [the full example here](https://queracomputing.github.io/bloqade/latest/digital/examples/interop/noisy_ghz/).
 
 ### Flow chart
 
@@ -123,7 +123,7 @@ Finally, noise is annotated after gates, where it is assumed that entangling gat
 
 ### GHZ data
 
-Now, let's look at some results of [the example](https://bloqade.quera.com/latest/digital/examples/interop/noisy_ghz/) that compares the different
+Now, let's look at some results of [the example](https://queracomputing.github.io/bloqade/latest/digital/examples/interop/noisy_ghz/) that compares the different
 noise processes.
 
 The different noise models lead to overall different infidelities of the circuit:
@@ -142,4 +142,4 @@ particular application.
 
 ## Learn more
 
-The future for Gemini is bright! Apart from demonstrating [logical magic state distillation](https://arxiv.org/abs/2412.15165), Gemini-class QPUs also form the foundation of QuEra's participation in the [Quantum for Bio](https://www.quera.com/press-releases/two-projects-powered-by-quera-computing-contributions-move-to-phase-three-of-wellcome-leaps-quantum-for-bio-challenge-focused-on-healthcare-and-biology-applications) program. QuEra will serve as the hardware provider for 2 of 6 of the teams that have advanced to the final phase of the challenge. With an eye towards general availability of Gemini-class devices, there's no better time for quantum developers to begin crafting circuits that are well-suited for Gemini. The [documentation for Bloqade-circuit](https://bloqade.quera.com/latest/digital/) as well as our [tutorial guides](https://bloqade.quera.com/latest/digital/examples/) are a great place to start.
+The future for Gemini is bright! Apart from demonstrating [logical magic state distillation](https://arxiv.org/abs/2412.15165), Gemini-class QPUs also form the foundation of QuEra's participation in the [Quantum for Bio](https://www.quera.com/press-releases/two-projects-powered-by-quera-computing-contributions-move-to-phase-three-of-wellcome-leaps-quantum-for-bio-challenge-focused-on-healthcare-and-biology-applications) program. QuEra will serve as the hardware provider for 2 of 6 of the teams that have advanced to the final phase of the challenge. With an eye towards general availability of Gemini-class devices, there's no better time for quantum developers to begin crafting circuits that are well-suited for Gemini. The [documentation for Bloqade-circuit](https://queracomputing.github.io/bloqade/latest/digital/) as well as our [tutorial guides](https://queracomputing.github.io/bloqade/latest/digital/examples/) are a great place to start.

--- a/docs/digital/tutorials/auto_parallelism.py
+++ b/docs/digital/tutorials/auto_parallelism.py
@@ -117,7 +117,7 @@ SVGCircuit(log_ghz)
 # ### The benefits of parallelism
 # We'll run noise simulations for both circuits and compare their fidelities as we scale the number of qubits.
 #
-# See our blog post [Simulating noisy circuits for near-term quantum hardware](https://bloqade.quera.com/latest/blog/2025/07/30/simulating-noisy-circuits-for-near-term-quantum-hardware/) for detailed information about the noise model used here. The analysis workflow is:
+# See our blog post [Simulating noisy circuits for near-term quantum hardware](https://queracomputing.github.io/bloqade/latest/blog/2025/07/30/simulating-noisy-circuits-for-near-term-quantum-hardware/) for detailed information about the noise model used here. The analysis workflow is:
 #
 # 1. Build a noiseless (ideal) circuit.
 # 2. Choose a noise model (we use the Gemini noise model).

--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -27,4 +27,4 @@ The first step in Bloqade was building out the analog mode SDK, designed to inte
 
 ## Join us!
 
-If you are interested in contributing, please see the contribution page [here](contrib.md). If you are interested in exploring more about neutral atom quantum computing, check out some analog tutorials [here](https://queracomputing.github.io/bloqade-analog-examples/dev/), and some circuit tutorials [here](https://bloqade.quera.com/latest/digital/). If you wish to work closer with QuEra, please feel free to reach out!
+If you are interested in contributing, please see the contribution page [here](contrib.md). If you are interested in exploring more about neutral atom quantum computing, check out some analog tutorials [here](https://queracomputing.github.io/bloqade-analog-examples/dev/), and some circuit tutorials [here](https://queracomputing.github.io/bloqade/latest/digital/). If you wish to work closer with QuEra, please feel free to reach out!

--- a/docs/quick_start/circuits/index.md
+++ b/docs/quick_start/circuits/index.md
@@ -106,7 +106,7 @@ sampler = circuit.compile_detector_sampler()
 detector_bits, observable_bits = sampler.sample(shots=1_000_000, separate_observables=True)
 
 ```
-A detailed tutorial of how to use TSIM for QEC workflows is available [here](https://bloqade.quera.com/latest/digital/examples/tsim/magic_state_distillation/).
+A detailed tutorial of how to use TSIM for QEC workflows is available [here](https://queracomputing.github.io/bloqade/latest/digital/examples/tsim/magic_state_distillation/).
 
 
 ### Hardware execution

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ repo_url: https://github.com/QuEraComputing/bloqade
 site_description: >-
   Bloqade - the neutral atom SDK
 edit_uri: "edit/main/docs/"
-site_url: https://bloqade.quera.com/
+site_url: https://queracomputing.github.io/bloqade/
 
 # Page tree
 nav:


### PR DESCRIPTION
## Summary
- Set MkDocs `site_url` to `https://queracomputing.github.io/bloqade/` so mike builds correct asset/version links for project Pages.
- Update README and in-repo doc links that still pointed at `bloqade.quera.com`.

Deploy workflows are unchanged: they already push versioned docs to `gh-pages` via `mike`.

## Follow-up (manual)
After merge, in the GitHub repo Pages settings:
1. Remove the `bloqade.quera.com` custom domain (and any `CNAME` on `gh-pages` if present).
2. Confirm Pages is serving from the `gh-pages` branch.
3. Trigger a docs deploy (merge to `main` or re-run the docs workflow) so the live site is rebuilt with the new `site_url`.

## Test plan
- [ ] Confirm `mkdocs.yml` `site_url` is `https://queracomputing.github.io/bloqade/`
- [ ] After merge + Pages custom-domain removal, open `https://queracomputing.github.io/bloqade/` and verify redirect/versioned docs load
- [ ] Spot-check CSS/JS and version selector on `/latest/` and `/dev/`
- [ ] Confirm README documentation badge/links resolve to the new host


Made with [Cursor](https://cursor.com)